### PR TITLE
Add description for column option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4 - 2019-11-06
+
+* [enhancement] Add DATETIME type conveter (thanks to @kekekenta)
+
 ## 0.6.3 - 2019-10-28
 
 * [enhancement] Add DATE type conveter (thanks to @tksfjt1024)

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Column options are used to aid guessing BigQuery schema, or to define conversion
   - **fields**: Describes the nested schema fields if the type property is set to RECORD. Please note that this is **required** for `RECORD` column.
   - **timestamp_format**: timestamp format to convert into/from `timestamp` (string, default is `default_timestamp_format`)
   - **timezone**: timezone to convert into/from `timestamp`, `date` (string, default is `default_timezone`).
+  - **description**: description for the column.
 - **default_timestamp_format**: default timestamp format for column_options (string, default is "%Y-%m-%d %H:%M:%S.%6N")
 - **default_timezone**: default timezone for column_options (string, default is "UTC")
 

--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-output-bigquery"
-  spec.version       = "0.6.3"
+  spec.version       = "0.6.4"
   spec.authors       = ["Satoshi Akama", "Naotoshi Seo"]
   spec.summary       = "Google BigQuery output plugin for Embulk"
   spec.description   = "Embulk plugin that insert records to Google BigQuery."

--- a/lib/embulk/output/bigquery/helper.rb
+++ b/lib/embulk/output/bigquery/helper.rb
@@ -50,6 +50,7 @@ module Embulk
               field[:type]   = (column_option['type'] || bq_type_from_embulk_type(embulk_type)).upcase
               field[:mode]   = column_option['mode'] if column_option['mode']
               field[:fields] = deep_symbolize_keys(column_option['fields']) if column_option['fields']
+              field[:description] = column_option['description'] if column_option['description']
             end
           end
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,12 +71,12 @@ module Embulk
               {'name' => 'boolean',   'type' => 'STRING', 'mode' => 'REQUIRED'},
               {'name' => 'long',      'type' => 'STRING'},
               {'name' => 'double',    'type' => 'STRING'},
-              {'name' => 'string',    'type' => 'INTEGER'},
+              {'name' => 'string',    'type' => 'INTEGER', 'description' => 'memo'},
               {'name' => 'timestamp', 'type' => 'INTEGER'},
               {'name' => 'date',      'type' => 'DATE'},
               {'name' => 'datetime',  'type' => 'DATETIME'},
               {'name' => 'json',      'type' => 'RECORD', 'fields' => [
-                { 'name' => 'key1',   'type' => 'STRING' },
+                { 'name' => 'key1',   'type' => 'STRING', 'description' => 'nested_memo'},
               ]},
             ],
           }
@@ -84,12 +84,12 @@ module Embulk
             {name: 'boolean',   type: 'STRING', mode: 'REQUIRED'},
             {name: 'long',      type: 'STRING'},
             {name: 'double',    type: 'STRING'},
-            {name: 'string',    type: 'INTEGER'},
+            {name: 'string',    type: 'INTEGER', description: 'memo'},
             {name: 'timestamp', type: 'INTEGER'},
             {name: 'date',      type: 'DATE'},
             {name: 'datetime',  type: 'DATETIME'},
             {name: 'json',      type: 'RECORD', fields: [
-              {name: 'key1',    type: 'STRING'},
+              {name: 'key1',    type: 'STRING', description: 'nested_memo'},
             ]},
           ]
           fields = Helper.fields_from_embulk_schema(task, schema)


### PR DESCRIPTION
add a description for each column


```
out:
  type: bigquery
  ...
  column_options:
  - name: id
    type: INTEGER
    mode: NULLABLE
  - name: name
    type: STRING
    mode: NULLABLE
    description: "memo"
  - name: ts
    type: TIMESTAMP
    mode: NULLABLE
    timestamp_format: "%Y-%m-%d %H:%M:%S.%N"
  - name: dt
    type: TIMESTAMP
    mode: NULLABLE
    timestamp_format: "%Y-%m-%d %H:%M:%S.%N"
```

[![Screenshot from Gyazo](https://gyazo.com/3c63e9f0ab9d19ed3bc197b19707b5e0/raw)](https://gyazo.com/3c63e9f0ab9d19ed3bc197b19707b5e0)





nested fileds

```
out:
  type: bigquery
  ...
  column_options:
  - name: id
    type: INTEGER
    mode: NULLABLE
  - name: name
    type: STRING
    mode: NULLABLE
    description: "memo"
  - name: nested
    type: RECORD
    mode: NULLABLE
    fields: 
      - name: nested
        type: STRING
        mode: NULLABLE
        description: "nested memo"
  - name: ts
    type: TIMESTAMP
    mode: NULLABLE
    timestamp_format: "%Y-%m-%d %H:%M:%S.%N"
  - name: dt
    type: TIMESTAMP
    mode: NULLABLE
    timestamp_format: "%Y-%m-%d %H:%M:%S.%N"
```

[![Screenshot from Gyazo](https://gyazo.com/3d449d3239f54ef8692f13a56032126c/raw)](https://gyazo.com/3d449d3239f54ef8692f13a56032126c)