### PR TITLE
column option has the highest priority for description

### DIFF
--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -399,10 +399,7 @@ module Embulk
             end
           end
 
-          if task['mode'] == 'append' || task['mode'] == 'append_direct'
-            # update only column.description based on column_options
-            bigquery.patch_table
-          end
+          bigquery.patch_table
 
         ensure
           begin

--- a/test/test_transaction.rb
+++ b/test/test_transaction.rb
@@ -91,6 +91,7 @@ module Embulk
             mock(obj).get_dataset(config['dataset'])
             mock(obj).delete_table_or_partition(config['table'])
             mock(obj).create_table_if_not_exists(config['table'])
+            mock(obj).patch_table
           end
           Bigquery.transaction(config, schema, processor_count, &control)
         end
@@ -102,6 +103,7 @@ module Embulk
             mock(obj).get_dataset(config['dataset'])
             mock(obj).delete_table_or_partition(config['table'])
             mock(obj).create_table_if_not_exists(config['table'])
+            mock(obj).patch_table
           end
           Bigquery.transaction(config, schema, processor_count, &control)
         end
@@ -117,6 +119,7 @@ module Embulk
             mock(obj).create_table_if_not_exists(config['table'])
             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
             mock(obj).delete_table(config['temp_table'])
+            mock(obj).patch_table
           end
           Bigquery.transaction(config, schema, processor_count, &control)
         end
@@ -130,6 +133,7 @@ module Embulk
             mock(obj).create_table_if_not_exists(config['table'])
             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
             mock(obj).delete_table(config['temp_table'])
+            mock(obj).patch_table
           end
           Bigquery.transaction(config, schema, processor_count, &control)
         end
@@ -151,6 +155,7 @@ module Embulk
 
             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
             mock(obj).delete_table(config['temp_table'])
+            mock(obj).patch_table
           end
           Bigquery.transaction(config, schema, processor_count, &control)
         end
@@ -170,6 +175,7 @@ module Embulk
 
             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
             mock(obj).delete_table(config['temp_table'])
+            mock(obj).patch_table
           end
           Bigquery.transaction(config, schema, processor_count, &control)
         end
@@ -189,6 +195,7 @@ module Embulk
 
             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
             mock(obj).delete_table(config['temp_table'])
+            mock(obj).patch_table
           end
           Bigquery.transaction(config, schema, processor_count, &control)
         end


### PR DESCRIPTION
column_option.description is executed for all modes. This change is especially for a config with template_table. If template_table is used for description, operator have to modify schema definition in Bigquery console. It's better to have all control in by embulk