### PR TITLE
retry with SSLError

### DIFF
--- a/lib/embulk/output/bigquery/google_client.rb
+++ b/lib/embulk/output/bigquery/google_client.rb
@@ -66,7 +66,7 @@ module Embulk
             # httpclient which google-api-ruby-client depends on, catches java.net.SocketException and java.net.ConnectionException and
             # raises SSLError.
             # https://github.com/nahi/httpclient/blob/4658227a46f7caa633ef8036f073bbd1f0a955a2/lib/httpclient/jruby_ssl_socket.rb#L124-L134
-          rescue SSLError => e
+          rescue OpenSSL::SSL::SSLError => e
             retry_messages = [
               "Java::JavaNet::SocketException: Connection reset",
               "Java::JavaNet::SocketException: Broken pipe",

--- a/lib/embulk/output/bigquery/google_client.rb
+++ b/lib/embulk/output/bigquery/google_client.rb
@@ -49,19 +49,6 @@ module Embulk
           retries = 0
           begin
             yield
-          rescue ::Java::Java.net.SocketException, ::Java::Java.net.ConnectException => e
-            if ['Broken pipe', 'Connection reset', 'Connection timed out'].include?(e.message)
-              if retries < @task['retries']
-                retries += 1
-                Embulk.logger.warn { "embulk-output-bigquery: retry \##{retries}, #{e.class} #{e.message}" }
-                retry
-              else
-                Embulk.logger.error { "embulk-output-bigquery: retry exhausted \##{retries}, #{e.class} #{e.message}" }
-                raise e
-              end
-            else
-              raise e
-            end
 
             # httpclient which google-api-ruby-client depends on, catches java.net.SocketException and java.net.ConnectionException and
             # raises SSLError.


### PR DESCRIPTION
httpclient which google-api-ruby-client depends on, catches java.net.SocketException and java.net.ConnectionException and raises SSLError.

