### PR TITLE
Merge `embulk-output-bigquery v0.6.9`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.9 - 2023-03-16
+* [enhancement] Add SSLException to retry job (thanks to @mzumi)
+
 ## 0.6.8 - 2022-10-12
 * [enhancement] Support JSON type (thanks to @civitaspo )
 * [maintenance] Add an error message in order to retry (thanks to @mzumi)

--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-output-bigquery"
-  spec.version       = "0.6.8"
+  spec.version       = "0.6.9"
   spec.authors       = ["Satoshi Akama", "Naotoshi Seo"]
   spec.summary       = "Google BigQuery output plugin for Embulk"
   spec.description   = "Embulk plugin that insert records to Google BigQuery."

--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-output-bigquery"
-  spec.version       = "0.7.1"
+  spec.version       = "0.7.2"
   spec.authors       = ["Satoshi Akama", "Naotoshi Seo"]
   spec.summary       = "Google BigQuery output plugin for Embulk"
   spec.description   = "Embulk plugin that insert records to Google BigQuery."

--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-output-bigquery"
-  spec.version       = "0.7.2"
+  spec.version       = "0.6.9.trocco.0.0.1"
   spec.authors       = ["Satoshi Akama", "Naotoshi Seo"]
   spec.summary       = "Google BigQuery output plugin for Embulk"
   spec.description   = "Embulk plugin that insert records to Google BigQuery."

--- a/lib/embulk/output/bigquery/google_client.rb
+++ b/lib/embulk/output/bigquery/google_client.rb
@@ -49,7 +49,7 @@ module Embulk
           retries = 0
           begin
             yield
-          rescue ::Java::Java.net.SocketException, ::Java::Java.net.ConnectException => e
+          rescue ::Java::Java.net.SocketException, ::Java::Java.net.ConnectException, ::Java::JavaxNetSsl::SSLException => e
             retry_messages = [
               'Broken pipe',
               'Connection reset',


### PR DESCRIPTION
I merged latest `embulk/embulk-output-bigquery` and bumped up version to ~~`0.7.2`~~ `0.6.9.trocco.0.0.1`