### PR TITLE
fix: remove rescue around bigquery.patch_table because it works correctly even if the original issue crops up

### DIFF
--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -407,12 +407,7 @@ module Embulk
             end
           end
 
-          begin
-            bigquery.patch_table
-          rescue => e
-            Embulk.logger.warn("patch_table is failed")
-            Embulk.logger.warn("#{e.class} : #{e.message}")
-          end
+          bigquery.patch_table
 
         ensure
           begin


### PR DESCRIPTION
If table was deleted during copying it, `bigquery.patch_table` should fail.
This problem may crop up if table was configured as "auto-delete".

This `rescue` was added in pull-request(https://github.com/trocco-io/embulk-output-bigquery/pull/19), but the original issue didn't need this `rescue`. Only changing location of `bigquery.patch_table` was needed to resolve it.

So I removed this `rescue`.
