### PR TITLE
udpate runs-on from ubuntu-latest to ubuntu-22.04

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,9 @@ name: Check
 on: [ pull_request, push ]
 jobs:
   check:
-    runs-on: ubuntu-latest
+    # https://github.com/ruby/ruby-builder/releases/tag/toolcache
+    # No support for jruby-9.1.17.0 after ubuntu-24.04
+    runs-on: ubuntu-22.04
     # push: always run.
     # pull_request: run only when the PR is submitted from a forked repository, not within this repository.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
The CI test fails because ubuntu 24.04 does not support jruby-9.1.17.
So ubuntu 22.04 is used.

Error example: https://github.com/trocco-io/embulk-output-bigquery/actions/runs/14281546453/job/40031655716?pr=33