### PR TITLE
Fixed issue where time_partitioning settings were overridden

### DIFF
--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -244,7 +244,7 @@ module Embulk
           if task['range_partitioning']
             raise ConfigError.new "Partition decorators(`#{task['table']}`) don't support `range_partition`"
           end
-          task['time_partitioning'] = {'type' => 'DAY'}
+          task['time_partitioning'] ||= {'type' => 'DAY'}
         end
 
         if task['range_partitioning']


### PR DESCRIPTION
This is a fix for a bug that was introduced when merging from origin.
The cause is a mistake in the following PR.
https://github.com/embulk/embulk-output-bigquery/pull/174
https://github.com/embulk/embulk-output-bigquery/pull/174/files#diff-d6b53be98c3e0abbdce934dd58c21b2d85b7da5cd5c4b81d5218d87b65b76fecR235-R246
