### PR TITLE
Support AWS Role Chaining for Workload Identity Federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,16 +286,18 @@ out:
 
 #### workload\_identity\_federation
 
-Use Workload Identity Federation to authenticate using AWS credentials to access Google Cloud resources.
-This allows users to authenticate without storing Google Cloud service account keys by leveraging AWS IAM credentials.
+Use Workload Identity Federation to authenticate to Google Cloud resources.
+This allows users to authenticate without storing static credentials by leveraging AWS IAM Role Chaining.
 
-| name                                 | type        | required?  | default           | description            |
-|:-------------------------------------|:------------|:-----------|:------------------|:-----------------------|
-| workload_identity_federation.config | string | required   |                   | Path to the Workload Identity Federation JSON config file or `content` |
-| workload_identity_federation.aws_access_key_id | string | required |                | AWS Access Key ID |
-| workload_identity_federation.aws_secret_access_key | string | required |            | AWS Secret Access Key |
-| workload_identity_federation.aws_session_token | string | optional   |                   | AWS Session Token (for temporary credentials) |
-| workload_identity_federation.aws_region | string | optional   | "ap-northeast-1"  | AWS Region |
+The plugin uses AWS AssumeRole to obtain temporary credentials from the base credentials (IRSA, ECS Task Role, etc.),
+and automatically refreshes them before expiration (1-hour session limit with 5-minute refresh threshold).
+
+| name                                 | type        | required?  | default                  | description            |
+|:-------------------------------------|:------------|:-----------|:-------------------------|:-----------------------|
+| workload_identity_federation.config | string | required   |                          | Path to the Workload Identity Federation JSON config file or `content` |
+| workload_identity_federation.aws_role_arn | string | required |                      | ARN of the AWS IAM Role to assume |
+| workload_identity_federation.aws_role_session_name | string | optional | "embulk-bigquery-session" | Session name for AssumeRole |
+| workload_identity_federation.aws_region | string | optional   | "ap-northeast-1"         | AWS Region |
 
 This plugin supports two access methods depending on the `config` content:
 
@@ -310,8 +312,8 @@ out:
   auth_method: workload_identity_federation
   workload_identity_federation:
     config: /path/to/workload-identity-federation-config.json
-    aws_access_key_id: AKIAXXXXXXXXXXXXXXXX
-    aws_secret_access_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    aws_role_arn: arn:aws:iam::123456789012:role/my-wif-role
+    aws_role_session_name: embulk-bigquery-session
     aws_region: ap-northeast-1
   project: my-project
   dataset: my_dataset

--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-output-bigquery"
-  spec.version       = "0.7.5.trocco.0.0.5"
+  spec.version       = "0.7.5.trocco.0.0.6"
   spec.authors       = ["Satoshi Akama", "Naotoshi Seo"]
   spec.summary       = "Google BigQuery output plugin for Embulk"
   spec.description   = "Embulk plugin that insert records to Google BigQuery."

--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -27,6 +27,14 @@ Gem::Specification.new do |spec|
   # googleauth 0.9.0 requires faraday ~> 0.12
   spec.add_dependency "faraday", '~> 0.12'
 
+  # AWS SDK for STS (AssumeRole for Role Chaining in WIF)
+  # Versions are pinned for JRuby 9.1.x (Ruby 2.3) compatibility.
+  # aws-sdk-sts >= 1.10.0 requires Ruby >= 2.5
+  # aws-sdk-core >= 3.131.0 requires Ruby >= 2.5
+  spec.add_dependency 'aws-sdk-sts', '= 1.9.0'
+  spec.add_dependency 'aws-sdk-core', '= 3.130.2'
+  spec.add_dependency 'aws-eventstream', '= 1.1.1'
+
   spec.add_development_dependency 'bundler', ['>= 1.10.6']
   spec.add_development_dependency 'rake', ['>= 10.0']
 end

--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -148,12 +148,12 @@ module Embulk
           if wif['config'].nil?
             raise ConfigError.new "`workload_identity_federation.config` is required"
           end
-          if wif['aws_access_key_id'].nil?
-            raise ConfigError.new "`workload_identity_federation.aws_access_key_id` is required"
+
+          if wif['aws_role_arn'].nil?
+            raise ConfigError.new "`workload_identity_federation.aws_role_arn` is required for WIF authentication"
           end
-          if wif['aws_secret_access_key'].nil?
-            raise ConfigError.new "`workload_identity_federation.aws_secret_access_key` is required"
-          end
+          Embulk.logger.info { "embulk-output-bigquery: WIF configured (aws_role_arn: #{wif['aws_role_arn']})" }
+
           wif['aws_region'] ||= 'ap-northeast-1'
           wif['config'] = LocalFile.load(wif['config'])
         end

--- a/lib/embulk/output/bigquery/aws_role_credentials_supplier.rb
+++ b/lib/embulk/output/bigquery/aws_role_credentials_supplier.rb
@@ -1,0 +1,81 @@
+require 'aws-sdk-sts'
+
+module Embulk
+  module Output
+    class Bigquery < OutputPlugin
+      # AWS Role Chaining用の認証情報サプライヤー
+      # AssumeRoleで一時認証情報を取得し、期限前に自動リフレッシュする
+      class AwsRoleCredentialsSupplier
+        # Role Chainingの最大セッション時間（AWS制限: 1時間）
+        SESSION_DURATION_SECONDS = 3600
+
+        # 期限5分前にリフレッシュ
+        REFRESH_THRESHOLD_SECONDS = 300
+
+        def initialize(role_arn:, role_session_name: nil, region: nil)
+          @role_arn = role_arn
+          @role_session_name = role_session_name || 'embulk-bigquery-session'
+          @region = region || 'ap-northeast-1'
+
+          @credentials = nil
+          @expiration_time = nil
+          @mutex = Mutex.new
+
+          Embulk.logger.info { "embulk-output-bigquery: AwsRoleCredentialsSupplier initialized for role: #{@role_arn}" }
+        end
+
+        # AWS認証情報を取得（必要に応じてリフレッシュ）
+        # @return [Hash] aws_access_key_id, aws_secret_access_key, aws_session_token
+        def get_credentials
+          @mutex.synchronize do
+            refresh_if_needed
+            {
+              'aws_access_key_id' => @credentials.access_key_id,
+              'aws_secret_access_key' => @credentials.secret_access_key,
+              'aws_session_token' => @credentials.session_token
+            }
+          end
+        end
+
+        private
+
+        def refresh_if_needed
+          return unless should_refresh?
+
+          Embulk.logger.info { "embulk-output-bigquery: Refreshing AWS credentials via AssumeRole" }
+          assume_role
+          Embulk.logger.info { "embulk-output-bigquery: AWS credentials refreshed, expires at: #{@expiration_time}" }
+        end
+
+        def should_refresh?
+          return true if @credentials.nil? || @expiration_time.nil?
+
+          # 期限切れ、または期限5分前ならリフレッシュ
+          refresh_threshold = Time.now + REFRESH_THRESHOLD_SECONDS
+          refresh_threshold >= @expiration_time
+        end
+
+        def assume_role
+          # DefaultCredentialsProviderを使用（IRSA, ECS Task Role, 環境変数など）
+          sts_client = Aws::STS::Client.new(region: @region)
+
+          Embulk.logger.debug { "embulk-output-bigquery: Calling STS AssumeRole for #{@role_arn}" }
+
+          response = sts_client.assume_role(
+            role_arn: @role_arn,
+            role_session_name: @role_session_name,
+            duration_seconds: SESSION_DURATION_SECONDS
+          )
+
+          @credentials = response.credentials
+          @expiration_time = response.credentials.expiration
+
+          Embulk.logger.debug { "embulk-output-bigquery: AssumeRole succeeded, session: #{@role_session_name}" }
+        rescue Aws::STS::Errors::ServiceError => e
+          Embulk.logger.error { "embulk-output-bigquery: AssumeRole failed: #{e.class} - #{e.message}" }
+          raise ConfigError.new("AWS AssumeRole failed for #{@role_arn}: #{e.message}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- WIF認証でAWS Role Chainingをサポート
- `aws_role_arn` を指定することで、AssumeRoleによる一時認証情報を自動取得・リフレッシュ
- 認証情報は期限5分前に自動更新

## Changes
- `AwsRoleCredentialsSupplier` クラスを新規追加（スレッドセーフな認証情報管理）
- `WorkloadIdentityFederationAuth` をRole Chaining対応に変更
- `aws-sdk-sts` 依存を追加（JRuby 9.1.x互換バージョン）

## Configuration
```yaml
out:
  type: bigquery
  auth_method: workload_identity_federation
  workload_identity_federation:
    config: /path/to/wif_config.json
    aws_role_arn: arn:aws:iam::123456789012:role/your-role
    aws_role_session_name: embulk-session  # optional
    aws_region: ap-northeast-1  # optional, default: ap-northeast-1
```

## Breaking Changes
- WIF認証で `aws_access_key_id` / `aws_secret_access_key` の直接指定は廃止
- `aws_role_arn` が必須パラメータに変更

🤖 Generated with [Claude Code](https://claude.ai/code)