### PR TITLE
fix: check policy tag permissions before copying to destination table

### DIFF
--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-output-bigquery"
-  spec.version       = "0.7.5.trocco.0.0.6"
+  spec.version       = "0.7.5.trocco.0.0.7"
   spec.authors       = ["Satoshi Akama", "Naotoshi Seo"]
   spec.summary       = "Google BigQuery output plugin for Embulk"
   spec.description   = "Embulk plugin that insert records to Google BigQuery."

--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -467,6 +467,14 @@ module Embulk
               end
             end
 
+            # Policy Tag permission check on temp table before copying to destination table
+            # This ensures that if policy tag application fails due to permission issues,
+            # the destination table remains unchanged
+            if task['temp_table'] && task['mode'] == 'replace' && task['retain_column_policy_tags']
+              Embulk.logger.info { "embulk-output-bigquery: checking policy tag permissions on temp table" }
+              bigquery.patch_table(task['temp_table'])
+            end
+
             if task['temp_table']
               case task['mode']
               when 'merge'

--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -543,9 +543,10 @@ module Embulk
         end
 
         # update only column.description
-        def patch_table
+        def patch_table(target_table = nil)
+          target_table ||= @task['table']
           with_job_retry do
-            table = get_table(@task['table'])
+            table = get_table(target_table)
 
             def patch_description_and_policy_tags(fields, column_options, src_fields)
               fields.map do |field|
@@ -573,7 +574,7 @@ module Embulk
 
             fields = patch_description_and_policy_tags(table.schema.fields, @task['column_options'], @src_fields)
             table.schema.update!(fields: fields)
-            table_id = Helper.chomp_partition_decorator(@task['table'])
+            table_id = Helper.chomp_partition_decorator(target_table)
             with_network_retry { client.patch_table(@destination_project, @dataset, table_id, table) }
           end
         end

--- a/test/test_transaction.rb
+++ b/test/test_transaction.rb
@@ -161,9 +161,10 @@ module Embulk
             mock(obj).get_table(config['table'])
             mock(obj).create_table_if_not_exists(config['temp_table'], options: {"expiration_time"=>nil})
             mock(obj).create_table_if_not_exists(config['table'])
+            mock(obj).patch_table(config['temp_table'])  # Policy tag permission check on temp table
             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
             mock(obj).delete_table(config['temp_table'])
-            mock(obj).patch_table
+            mock(obj).patch_table  # Apply policy tags to destination table
           end
           Bigquery.transaction(config, schema, processor_count, &control)
         end


### PR DESCRIPTION
## Summary

- Add policy tag permission check on temp table before copying to destination table when `retain_column_policy_tags` is enabled in `replace` mode
- If the permission check fails, skip the copy operation and leave the destination table unchanged

## Background

In the current implementation, policy tags are applied after data is copied to the destination table. If a permission error occurs during policy tag application, the data has already been overwritten but the policy tags are lost.

## Changes

1. Extend `patch_table` method to accept an optional table name argument
2. When `replace` mode and `retain_column_policy_tags` are enabled, perform policy tag permission check on temp table before copying to destination table
3. If permission check fails, raise an error and skip copying to destination table

## Test plan

- [ ] Verify `test_replace_with_retain_column_policy_tags` test passes

🤖 Generated with [Claude Code](https://claude.ai/code)