### PR TITLE
fix: add table alias to VALUES clause in MERGE query

### DIFF
--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-output-bigquery"
-  spec.version       = "0.7.5.trocco.0.0.7"
+  spec.version       = "0.7.5.trocco.0.0.8"
   spec.authors       = ["Satoshi Akama", "Naotoshi Seo"]
   spec.summary       = "Google BigQuery output plugin for Embulk"
   spec.description   = "Embulk plugin that insert records to Google BigQuery."

--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -589,7 +589,7 @@ module Embulk
                UPDATE SET #{join_merge_rule_or_columns(merge_rule, columns)}
              WHEN NOT MATCHED THEN
                INSERT (#{join_columns(columns)})
-               VALUES (#{join_columns(columns)})
+               VALUES (#{join_columns(columns, 'S')})
           EOD
           Embulk.logger.info { "embulk-output-bigquery: Execute query... #{query.gsub(/\s+/, ' ')}" }
           execute_query(query)
@@ -655,8 +655,12 @@ module Embulk
           merge_rule_or_columns.join(", ")
         end
 
-        def join_columns(columns)
-          columns.map { |column| "`#{column}`" }.join(", ")
+        def join_columns(columns, table_alias = nil)
+          if table_alias
+            columns.map { |column| "#{table_alias}.`#{column}`" }.join(", ")
+          else
+            columns.map { |column| "`#{column}`" }.join(", ")
+          end
         end
 
         def execute_query(query)


### PR DESCRIPTION
## Summary

- Add source table alias `S.` to VALUES clause in MERGE mode
- Fix schema sync failure when table name and column name are identical (e.g., `KyujinKoukoku__c`)

## Background

When table name and column name are identical, BigQuery interprets the column reference in VALUES clause as a reference to the entire table (STRUCT type), causing the following error:

```
Google::Apis::ClientError: invalidQuery: Query column has type STRUCT<...> which cannot be inserted into column KyujinKoukoku__c, which has type STRING
```

## Changes

- Add optional `table_alias` argument to `join_columns` method
- Call `join_columns(columns, 'S')` in VALUES clause to explicitly reference source table columns

## Test plan

- [ ] Verify MERGE mode schema sync works correctly when table name and column name are identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)