### PR TITLE
fix: clear policy tags from temp table before copy to avoid access denied error

### DIFF
--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-output-bigquery"
-  spec.version       = "0.7.5.trocco.0.0.9.test"
+  spec.version       = "0.7.5.trocco.0.0.9"
   spec.authors       = ["Satoshi Akama", "Naotoshi Seo"]
   spec.summary       = "Google BigQuery output plugin for Embulk"
   spec.description   = "Embulk plugin that insert records to Google BigQuery."

--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-output-bigquery"
-  spec.version       = "0.7.5.trocco.0.0.7"
+  spec.version       = "0.7.5.trocco.0.0.9.test"
   spec.authors       = ["Satoshi Akama", "Naotoshi Seo"]
   spec.summary       = "Google BigQuery output plugin for Embulk"
   spec.description   = "Embulk plugin that insert records to Google BigQuery."

--- a/lib/embulk/output/bigquery.rb
+++ b/lib/embulk/output/bigquery.rb
@@ -473,6 +473,10 @@ module Embulk
             if task['temp_table'] && task['mode'] == 'replace' && task['retain_column_policy_tags']
               Embulk.logger.info { "embulk-output-bigquery: checking policy tag permissions on temp table" }
               bigquery.patch_table(task['temp_table'])
+              # Remove policy tags from temp table before copy to avoid access denied error
+              # Users with Policy Tag Admin role can apply tags but cannot read tagged data
+              Embulk.logger.info { "embulk-output-bigquery: clearing policy tags from temp table before copy" }
+              bigquery.clear_policy_tags(task['temp_table'])
             end
 
             if task['temp_table']

--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -586,7 +586,10 @@ module Embulk
 
             def clear_policy_tags_from_fields(fields)
               fields.map do |field|
-                field.update!(policy_tags: nil) if field.policy_tags
+                if field.policy_tags
+                  # Set empty names array to remove policy tags
+                  field.policy_tags.update!(names: [])
+                end
                 if field.fields
                   nested_fields = clear_policy_tags_from_fields(field.fields)
                   field.update!(fields: nested_fields)

--- a/test/test_transaction.rb
+++ b/test/test_transaction.rb
@@ -162,6 +162,7 @@ module Embulk
             mock(obj).create_table_if_not_exists(config['temp_table'], options: {"expiration_time"=>nil})
             mock(obj).create_table_if_not_exists(config['table'])
             mock(obj).patch_table(config['temp_table'])  # Policy tag permission check on temp table
+            mock(obj).clear_policy_tags(config['temp_table'])  # Clear policy tags before copy
             mock(obj).copy(config['temp_table'], config['table'], write_disposition: 'WRITE_TRUNCATE')
             mock(obj).delete_table(config['temp_table'])
             mock(obj).patch_table  # Apply policy tags to destination table


### PR DESCRIPTION
## Summary
- Fix access denied error when users with Policy Tag Admin role perform full table replacement in replace mode
- Policy Tag Admin can apply tags but cannot read policy-tagged data, so we now clear policy tags from temp table after permission check before copying

## Changes
1. `bigquery_client.rb`: Add `clear_policy_tags` method to remove policy tags from a table
2. `bigquery.rb`: Call `clear_policy_tags` after permission check and before copy operation

## Flow
1. Apply policy tags to temp table (permission check) → destination table remains unchanged if this fails
2. Clear policy tags from temp table → enables copy operation
3. Execute copy from temp table to destination
4. Apply policy tags to destination table (existing `patch_table` call)

## Test plan
- [ ] Run replace mode with `retain_column_policy_tags: true` using a user with only Policy Tag Admin role and verify it completes without error
- [ ] Verify policy tags are correctly applied to the destination table

🤖 Generated with [Claude Code](https://claude.com/claude-code)