### PR TITLE
feat: support recursive field conversion for RECORD type columns

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -14,12 +14,12 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
       - name: push gem
-        uses: trocco-io/push-gem-to-gpr-action@v1
+        uses: trocco-io/push-gem-to-gpr-action@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,50 @@
+name: Pull Request
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
+jobs:
+  test:
+    name: Test
+    # https://github.com/ruby/ruby-builder/releases/tag/toolcache
+    # No support for jruby-9.1.17.0 after ubuntu-24.04
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up OpenJDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: "temurin"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 'jruby-9.1.17.0'
+          bundler-cache: false
+      - name: install embulk.jar
+        run: "curl -L -o embulk.jar https://github.com/embulk/embulk/releases/download/v0.9.25/embulk-0.9.25.jar"
+      - name: chmod embulk.jar
+        run: "chmod a+x embulk.jar"
+      - name: bundle install
+        run: "./embulk.jar bundle install --path vendor/bundle"
+      - name: rake test
+        run: 'bundle exec env RUBYOPT="-r ./embulk.jar -r embulk -r embulk/java/bootstrap" rake test'
+  pre-release:
+    name: Pre-release
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Push gem
+        uses: trocco-io/push-gem-to-gpr-action@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,7 +44,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - name: Push gem
+      - name: Add commit hash suffix to version
+        run: |
+          commit_hash="${GITHUB_SHA:0:7}"
+          sed -ie "s/\(spec\.version \+= \+\"[^\"]\+\)/\1.${commit_hash}.pre/g" *.gemspec
+          grep spec.version *.gemspec
+      - name: Build and push gem
         uses: trocco-io/push-gem-to-gpr-action@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vendor/
 .tags
 your-project-000.json
 embulk.jar
+.idea

--- a/README.md
+++ b/README.md
@@ -384,7 +384,14 @@ Column options are used to aid guessing BigQuery schema, or to define conversion
     - json:      `STRING`,  `RECORD` (default: `STRING`)
     - numeric:   `STRING`
   - **mode**: BigQuery mode such as `NULLABLE`, `REQUIRED`, and `REPEATED` (string, default: `NULLABLE`)
-  - **fields**: Describes the nested schema fields if the type property is set to RECORD. Please note that this is **required** for `RECORD` column.
+  - **fields**: Describes the nested schema fields if the type property is set to RECORD. Please note that this is **required** for `RECORD` column. Each field supports the following options:
+    - **name**: field name (required)
+    - **type**: BigQuery type such as `BOOLEAN`, `INTEGER`, `FLOAT`, `STRING`, `TIMESTAMP`, `DATETIME`, `DATE`, `TIME`, `RECORD`, and `NUMERIC` (required)
+    - **mode**: `NULLABLE`, `REQUIRED`, or `REPEATED` (string, default: `NULLABLE`)
+    - **timestamp_format**: timestamp format for `TIMESTAMP`, `DATETIME` fields (string, default is `default_timestamp_format`)
+    - **timezone**: timezone for `TIMESTAMP`, `DATE` fields (string, default is `default_timezone`)
+    - **fields**: nested schema fields for `RECORD` type (recursive)
+    - **description**: description for the field
   - **description**: description (string, default is `None`).
   - **timestamp_format**: timestamp format to convert into/from `timestamp` (string, default is `default_timestamp_format`)
   - **timezone**: timezone to convert into/from `timestamp`, `date` (string, default is `default_timezone`).
@@ -405,7 +412,12 @@ out:
       type: RECORD
       fields:
         - {name: key1, type: STRING}
-        - {name: key2, type: STRING}
+        - {name: key2, type: TIMESTAMP, timestamp_format: "%Y-%m-%dT%H:%M:%S", timezone: "Asia/Tokyo"}
+        - name: nested
+          type: RECORD
+          fields:
+            - {name: value, type: STRING}
+            - {name: created_at, type: TIMESTAMP, timestamp_format: "%Y-%m-%d %H:%M:%S"}
 ```
 
 NOTE: Type conversion is done in this jruby plugin, and could be slow. See [Formatter Performance Issue](#formatter-performance-issue) to improve the performance.

--- a/embulk-output-bigquery.gemspec
+++ b/embulk-output-bigquery.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-output-bigquery"
-  spec.version       = "0.7.5.trocco.0.0.9"
+  spec.version       = "0.7.5.trocco.0.0.10"
   spec.authors       = ["Satoshi Akama", "Naotoshi Seo"]
   spec.summary       = "Google BigQuery output plugin for Embulk"
   spec.description   = "Embulk plugin that insert records to Google BigQuery."

--- a/lib/embulk/output/bigquery/value_converter_factory.rb
+++ b/lib/embulk/output/bigquery/value_converter_factory.rb
@@ -346,8 +346,10 @@ module Embulk
               source_type, type,
               timestamp_format: field_config['timestamp_format'],
               timezone: field_config['timezone'],
+              strict: @strict,
               default_timestamp_format: @default_timestamp_format,
               default_timezone: @default_timezone,
+              scale: @scale,
               fields: field_config['fields']
             ).create_converter
 

--- a/lib/embulk/output/bigquery/value_converter_factory.rb
+++ b/lib/embulk/output/bigquery/value_converter_factory.rb
@@ -255,7 +255,7 @@ module Embulk
             Proc.new {|val|
               next nil if val.nil?
               with_typecast_error(val) do |val|
-                BigDecimal(val).round(@scale, BigDecimal::ROUND_CEILING)
+                BigDecimal(val.to_s).round(@scale, BigDecimal::ROUND_CEILING)
               end
             }
           else
@@ -340,7 +340,7 @@ module Embulk
             mode = (field_config['mode'] || 'NULLABLE').upcase
             # Nested RECORD values are already Hashes from JSON.parse, use :json
             # Other values come as strings/primitives from JSON, use :string
-            source_type = type == 'RECORD' ? :json : :string
+            source_type = ['RECORD', 'JSON'].include?(type) ? :json : :string
 
             converter = self.class.new(
               source_type, type,

--- a/lib/embulk/output/bigquery/value_converter_factory.rb
+++ b/lib/embulk/output/bigquery/value_converter_factory.rb
@@ -39,7 +39,8 @@ module Embulk
               strict: column_option['strict'],
               default_timestamp_format: default_timestamp_format,
               default_timezone: default_timezone,
-              scale: scale
+              scale: scale,
+              fields: column_option['fields']
             ).create_converter
           end
         end
@@ -51,16 +52,19 @@ module Embulk
           timestamp_format: nil, timezone: nil, strict: nil,
           default_timestamp_format: DEFAULT_TIMESTAMP_FORMAT,
           default_timezone: DEFAULT_TIMEZONE,
-          scale: DEFAULT_SCALE
+          scale: DEFAULT_SCALE,
+          fields: nil
         )
           @embulk_type      = embulk_type
           @type             = (type || Helper.bq_type_from_embulk_type(embulk_type)).upcase
           @timestamp_format = timestamp_format
           @default_timestamp_format = default_timestamp_format
+          @default_timezone = default_timezone
           @timezone         = timezone || default_timezone
           @zone_offset      = TimeWithZone.zone_offset(@timezone)
           @strict           = strict.nil? ? true : strict
           @scale            = scale
+          @fields           = fields
         end
 
         def create_converter
@@ -173,8 +177,8 @@ module Embulk
           when 'BOOLEAN'
             Proc.new {|val|
               next nil if val.nil?
-              next true if val == 'true'.freeze
-              next false if val == 'false'.freeze
+              next true if (val == true) || (val == 'true'.freeze)
+              next false if (val == false) || (val == 'false'.freeze)
               raise_typecast_error(val)
             }
           when 'INTEGER'
@@ -239,10 +243,12 @@ module Embulk
               end
             }
           when 'RECORD'
+            record_field_converters = build_record_field_converters
             Proc.new {|val|
               next nil if val.nil?
               with_typecast_error(val) do |val|
-                JSON.parse(val)
+                parsed = JSON.parse(val)
+                apply_field_converters(parsed, record_field_converters)
               end
             }
           when 'NUMERIC'
@@ -302,7 +308,6 @@ module Embulk
           end
         end
 
-        # ToDo: recursive conversion
         def json_converter
           case type
           when 'STRING'
@@ -311,8 +316,10 @@ module Embulk
               val.to_json
             }
           when 'RECORD'
+            record_field_converters = build_record_field_converters
             Proc.new {|val|
-              val
+              next nil if val.nil?
+              apply_field_converters(val, record_field_converters)
             }
           when 'JSON'
             Proc.new {|val|
@@ -320,6 +327,54 @@ module Embulk
             }
           else
             raise NotSupportedType, "cannot take column type #{type} for json column"
+          end
+        end
+
+        def build_record_field_converters
+          return {} unless @fields.is_a?(Array) && !@fields.empty?
+
+          converters = {}
+          @fields.each do |field_config|
+            name = field_config['name']
+            type = field_config['type'].upcase
+            mode = (field_config['mode'] || 'NULLABLE').upcase
+            # Nested RECORD values are already Hashes from JSON.parse, use :json
+            # Other values come as strings/primitives from JSON, use :string
+            source_type = type == 'RECORD' ? :json : :string
+
+            converter = self.class.new(
+              source_type, type,
+              timestamp_format: field_config['timestamp_format'],
+              timezone: field_config['timezone'],
+              default_timestamp_format: @default_timestamp_format,
+              default_timezone: @default_timezone,
+              fields: field_config['fields']
+            ).create_converter
+
+            if mode == 'REPEATED'
+              converters[name] = Proc.new {|val|
+                next nil if val.nil?
+                val.map {|v| converter.call(v) }
+              }
+            else
+              converters[name] = converter
+            end
+          end
+          converters
+        end
+
+        def apply_field_converters(data, field_converters)
+          return data if field_converters.empty?
+
+          if data.is_a?(Array)
+            data.map {|element| apply_field_converters(element, field_converters) }
+          elsif data.is_a?(Hash)
+            field_converters.each do |name, converter|
+              data[name] = converter.call(data[name]) if data.key?(name)
+            end
+            data
+          else
+            data
           end
         end
       end

--- a/test/test_value_converter_factory.rb
+++ b/test/test_value_converter_factory.rb
@@ -632,7 +632,40 @@ module Embulk
           assert_equal '2024-02-20 15:00:00.000000 +00:00', result[1]['ts']
         end
 
-        # 7. 統合テスト
+        # 7. strict / scale の伝播
+
+        def test_strict_false_propagates_to_nested_fields
+          fields = [
+            {'name' => 'v', 'type' => 'INTEGER', 'mode' => 'NULLABLE'},
+          ]
+          converter = ValueConverterFactory.new(:string, 'RECORD', strict: false, fields: fields).create_converter
+
+          result = converter.call('{"v":"not_a_number"}')
+          assert_equal nil, result['v']
+        end
+
+        def test_strict_true_propagates_to_nested_fields
+          fields = [
+            {'name' => 'v', 'type' => 'INTEGER', 'mode' => 'NULLABLE'},
+          ]
+          converter = ValueConverterFactory.new(:string, 'RECORD', strict: true, fields: fields).create_converter
+
+          assert_raise(ValueConverterFactory::TypeCastError) do
+            converter.call('{"v":"not_a_number"}')
+          end
+        end
+
+        def test_scale_propagates_to_nested_numeric_fields
+          fields = [
+            {'name' => 'v', 'type' => 'NUMERIC', 'mode' => 'NULLABLE'},
+          ]
+          converter = ValueConverterFactory.new(:string, 'RECORD', scale: 2, fields: fields).create_converter
+
+          result = converter.call('{"v":"1.2345"}')
+          assert_equal BigDecimal('1.24'), result['v']
+        end
+
+        # 8. 統合テスト
 
         def test_create_converters_with_record_fields
           schema = Schema.new([

--- a/test/test_value_converter_factory.rb
+++ b/test/test_value_converter_factory.rb
@@ -439,6 +439,225 @@ module Embulk
         converter = ValueConverterFactory.new(:string, 'INTEGER', strict: false).create_converter
         assert_equal nil, converter.call('foo')
       end
+
+      class TestRecordFieldConverters < Test::Unit::TestCase
+        def build_converter(source_type, fields)
+          ValueConverterFactory.new(source_type, 'RECORD', fields: fields).create_converter
+        end
+
+        # 1. ソース型別の基本動作
+
+        def test_string_to_record_with_fields
+          fields = [
+            {'name' => 'key', 'type' => 'STRING', 'mode' => 'NULLABLE'},
+            {'name' => 'ts', 'type' => 'TIMESTAMP', 'mode' => 'NULLABLE', 'timestamp_format' => '%Y-%m-%dT%H:%M:%S'},
+          ]
+          converter = build_converter(:string, fields)
+
+          result = converter.call('{"key":"val","ts":"2024-01-15T10:30:00"}')
+          assert_equal 'val', result['key']
+          assert_equal '2024-01-15 10:30:00.000000 +00:00', result['ts']
+        end
+
+        def test_json_to_record_with_fields
+          fields = [
+            {'name' => 'key', 'type' => 'STRING', 'mode' => 'NULLABLE'},
+            {'name' => 'ts', 'type' => 'TIMESTAMP', 'mode' => 'NULLABLE', 'timestamp_format' => '%Y-%m-%dT%H:%M:%S'},
+          ]
+          converter = build_converter(:json, fields)
+
+          result = converter.call({'key' => 'val', 'ts' => '2024-01-15T10:30:00'})
+          assert_equal 'val', result['key']
+          assert_equal '2024-01-15 10:30:00.000000 +00:00', result['ts']
+        end
+
+        def test_nil_input
+          fields = [
+            {'name' => 'key', 'type' => 'STRING', 'mode' => 'NULLABLE'},
+          ]
+          assert_equal nil, build_converter(:string, fields).call(nil)
+          assert_equal nil, build_converter(:json, fields).call(nil)
+        end
+
+        # 2. フィールド型別（JSON.parse後のRubyネイティブ型が入力）
+
+        def test_field_type_string
+          fields = [{'name' => 'v', 'type' => 'STRING', 'mode' => 'NULLABLE'}]
+          result = build_converter(:string, fields).call('{"v":"hello"}')
+          assert_equal 'hello', result['v']
+        end
+
+        def test_field_type_integer
+          fields = [{'name' => 'v', 'type' => 'INTEGER', 'mode' => 'NULLABLE'}]
+          result = build_converter(:string, fields).call('{"v":42}')
+          assert_equal 42, result['v']
+        end
+
+        def test_field_type_float
+          fields = [{'name' => 'v', 'type' => 'FLOAT', 'mode' => 'NULLABLE'}]
+          result = build_converter(:string, fields).call('{"v":3.14}')
+          assert_equal 3.14, result['v']
+        end
+
+        def test_field_type_boolean
+          fields = [{'name' => 'v', 'type' => 'BOOLEAN', 'mode' => 'NULLABLE'}]
+          converter = build_converter(:string, fields)
+
+          result = converter.call('{"v":true}')
+          assert_equal true, result['v']
+
+          result = converter.call('{"v":false}')
+          assert_equal false, result['v']
+        end
+
+        def test_field_type_timestamp_with_format
+          fields = [{'name' => 'v', 'type' => 'TIMESTAMP', 'mode' => 'NULLABLE', 'timestamp_format' => '%Y-%m-%dT%H:%M:%S'}]
+          result = build_converter(:string, fields).call('{"v":"2024-01-15T10:30:00"}')
+          assert_equal '2024-01-15 10:30:00.000000 +00:00', result['v']
+        end
+
+        def test_field_type_timestamp_without_format
+          fields = [{'name' => 'v', 'type' => 'TIMESTAMP', 'mode' => 'NULLABLE'}]
+          result = build_converter(:string, fields).call('{"v":"2024-01-15 10:30:00"}')
+          assert_equal '2024-01-15 10:30:00', result['v']
+        end
+
+        def test_field_type_date
+          fields = [{'name' => 'v', 'type' => 'DATE', 'mode' => 'NULLABLE'}]
+          result = build_converter(:string, fields).call('{"v":"2024-01-15 10:30:00"}')
+          assert_equal '2024-01-15', result['v']
+        end
+
+        def test_field_type_datetime_with_format
+          fields = [{'name' => 'v', 'type' => 'DATETIME', 'mode' => 'NULLABLE', 'timestamp_format' => '%Y/%m/%d %H:%M:%S'}]
+          result = build_converter(:string, fields).call('{"v":"2024/01/15 10:30:00"}')
+          assert_equal '2024-01-15 10:30:00.000000', result['v']
+        end
+
+        def test_field_type_datetime_without_format
+          fields = [{'name' => 'v', 'type' => 'DATETIME', 'mode' => 'NULLABLE'}]
+          result = build_converter(:string, fields).call('{"v":"2024-01-15 10:30:00"}')
+          assert_equal '2024-01-15 10:30:00', result['v']
+        end
+
+        def test_field_type_time
+          fields = [{'name' => 'v', 'type' => 'TIME', 'mode' => 'NULLABLE'}]
+          result = build_converter(:string, fields).call('{"v":"15:30:00"}')
+          assert_equal '15:30:00.000000', result['v']
+        end
+
+        # 3. オプション（timezone）
+
+        def test_field_timestamp_with_timezone
+          fields = [{'name' => 'v', 'type' => 'TIMESTAMP', 'mode' => 'NULLABLE', 'timestamp_format' => '%Y-%m-%d', 'timezone' => 'Asia/Tokyo'}]
+          result = build_converter(:string, fields).call('{"v":"2024-01-15"}')
+          assert_equal '2024-01-15 00:00:00.000000 +09:00', result['v']
+        end
+
+        def test_field_timestamp_without_timezone_uses_default
+          fields = [{'name' => 'v', 'type' => 'TIMESTAMP', 'mode' => 'NULLABLE', 'timestamp_format' => '%Y-%m-%d'}]
+          result = build_converter(:string, fields).call('{"v":"2024-01-15"}')
+          assert_equal '2024-01-15 00:00:00.000000 +00:00', result['v']
+        end
+
+        # 4. mode
+
+        def test_repeated_string
+          fields = [{'name' => 'v', 'type' => 'STRING', 'mode' => 'REPEATED'}]
+          result = build_converter(:string, fields).call('{"v":["a","b","c"]}')
+          assert_equal ['a', 'b', 'c'], result['v']
+        end
+
+        def test_repeated_timestamp
+          fields = [{'name' => 'v', 'type' => 'TIMESTAMP', 'mode' => 'REPEATED', 'timestamp_format' => '%Y-%m-%dT%H:%M:%S'}]
+          result = build_converter(:string, fields).call('{"v":["2024-01-15T10:30:00","2024-02-20T15:00:00"]}')
+          assert_equal [
+            '2024-01-15 10:30:00.000000 +00:00',
+            '2024-02-20 15:00:00.000000 +00:00',
+          ], result['v']
+        end
+
+        def test_repeated_nil
+          fields = [{'name' => 'v', 'type' => 'STRING', 'mode' => 'REPEATED'}]
+          result = build_converter(:string, fields).call('{"v":null}')
+          assert_equal nil, result['v']
+        end
+
+        # 5. 再帰（ネストRECORD）
+
+        def test_nested_record
+          fields = [
+            {'name' => 'inner', 'type' => 'RECORD', 'mode' => 'NULLABLE', 'fields' => [
+              {'name' => 'ts', 'type' => 'TIMESTAMP', 'mode' => 'NULLABLE', 'timestamp_format' => '%Y-%m-%dT%H:%M:%S', 'timezone' => 'Asia/Tokyo'},
+            ]},
+          ]
+          result = build_converter(:string, fields).call('{"inner":{"ts":"2024-01-15T10:30:00"}}')
+          assert_equal '2024-01-15 10:30:00.000000 +09:00', result['inner']['ts']
+        end
+
+        def test_repeated_nested_record
+          fields = [
+            {'name' => 'items', 'type' => 'RECORD', 'mode' => 'REPEATED', 'fields' => [
+              {'name' => 'ts', 'type' => 'TIMESTAMP', 'mode' => 'NULLABLE', 'timestamp_format' => '%Y-%m-%dT%H:%M:%S'},
+            ]},
+          ]
+          result = build_converter(:string, fields).call('{"items":[{"ts":"2024-01-15T10:30:00"},{"ts":"2024-02-20T15:00:00"}]}')
+          assert_equal '2024-01-15 10:30:00.000000 +00:00', result['items'][0]['ts']
+          assert_equal '2024-02-20 15:00:00.000000 +00:00', result['items'][1]['ts']
+        end
+
+        # 6. エッジケース
+
+        def test_record_without_fields
+          converter = ValueConverterFactory.new(:string, 'RECORD').create_converter
+          assert_equal({'foo' => 'bar'}, converter.call('{"foo":"bar"}'))
+        end
+
+        def test_field_missing_in_data
+          fields = [
+            {'name' => 'key', 'type' => 'STRING', 'mode' => 'NULLABLE'},
+            {'name' => 'ts', 'type' => 'TIMESTAMP', 'mode' => 'NULLABLE', 'timestamp_format' => '%Y-%m-%dT%H:%M:%S'},
+          ]
+          result = build_converter(:string, fields).call('{"key":"hello"}')
+          assert_equal 'hello', result['key']
+          assert_false result.key?('ts')
+        end
+
+        def test_top_level_data_is_array
+          fields = [
+            {'name' => 'ts', 'type' => 'TIMESTAMP', 'mode' => 'NULLABLE', 'timestamp_format' => '%Y-%m-%dT%H:%M:%S'},
+          ]
+          result = build_converter(:string, fields).call('[{"ts":"2024-01-15T10:30:00"},{"ts":"2024-02-20T15:00:00"}]')
+          assert_equal '2024-01-15 10:30:00.000000 +00:00', result[0]['ts']
+          assert_equal '2024-02-20 15:00:00.000000 +00:00', result[1]['ts']
+        end
+
+        # 7. 統合テスト
+
+        def test_create_converters_with_record_fields
+          schema = Schema.new([
+            Column.new({index: 0, name: 'data', type: :json}),
+          ])
+          task = {
+            'column_options' => [
+              {
+                'name' => 'data',
+                'type' => 'RECORD',
+                'fields' => [
+                  {'name' => 'ts', 'type' => 'TIMESTAMP', 'mode' => 'NULLABLE', 'timestamp_format' => '%Y-%m-%dT%H:%M:%S'},
+                  {'name' => 'key', 'type' => 'STRING', 'mode' => 'NULLABLE'},
+                ],
+              },
+            ],
+          }
+          converters = ValueConverterFactory.create_converters(task, schema)
+
+          result = converters[0].call({'ts' => '2024-01-15T10:30:00', 'key' => 'hello'})
+          assert_equal '2024-01-15 10:30:00.000000 +00:00', result['ts']
+          assert_equal 'hello', result['key']
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add recursive field type conversion for RECORD type columns based on `fields` definition (TIMESTAMP, DATETIME, DATE, TIME, BOOLEAN, etc.)
- Support REPEATED mode and nested RECORD fields
- Add pre-release workflow to automatically publish gems with commit hash suffix to GPR on pull requests

## Changes
- `value_converter_factory.rb`: Add `fields` parameter and implement recursive type conversion via `build_record_field_converters` / `apply_field_converters` methods
- `test_value_converter_factory.rb`: Add comprehensive tests covering all field types, REPEATED mode, nested RECORD, and edge cases (+219 lines)
- `README.md`: Expand documentation for `fields` option
- `.github/workflows/pull-request.yml`: Add new pre-release workflow for PR builds
- `.github/workflows/gem-push.yml`: Update to actions/checkout@v4 and push-gem-to-gpr-action@v2

## Examples

### Basic RECORD with type conversion
```yaml
column_options:
  - name: data
    type: RECORD
    fields:
      - {name: key, type: STRING}
      - {name: ts, type: TIMESTAMP, timestamp_format: "%Y-%m-%dT%H:%M:%S"}
```
Input: `{"key": "hello", "ts": "2024-01-15T10:30:00"}`
Output: `{"key": "hello", "ts": "2024-01-15 10:30:00.000000 +00:00"}`

### Nested RECORD with timezone
```yaml
column_options:
  - name: data
    type: RECORD
    fields:
      - name: inner
        type: RECORD
        fields:
          - {name: ts, type: TIMESTAMP, timestamp_format: "%Y-%m-%dT%H:%M:%S", timezone: "Asia/Tokyo"}
          - {name: label, type: STRING}
```
Input: `{"inner": {"ts": "2024-01-15T10:30:00", "label": "value"}}`
Output: `{"inner": {"ts": "2024-01-15 10:30:00.000000 +09:00", "label": "value"}}`

### REPEATED RECORD
```yaml
column_options:
  - name: data
    type: RECORD
    fields:
      - name: items
        type: RECORD
        mode: REPEATED
        fields:
          - {name: ts, type: TIMESTAMP, timestamp_format: "%Y-%m-%dT%H:%M:%S"}
          - {name: name, type: STRING}
```
Input: `{"items": [{"ts": "2024-01-15T10:30:00", "name": "item1"}, {"ts": "2024-02-20T15:00:00", "name": "item2"}]}`
Output: `{"items": [{"ts": "2024-01-15 10:30:00.000000 +00:00", "name": "item1"}, {"ts": "2024-02-20 15:00:00.000000 +00:00", "name": "item2"}]}`

### Various field types
```yaml
column_options:
  - name: data
    type: RECORD
    fields:
      - {name: str, type: STRING}
      - {name: int, type: INTEGER}
      - {name: flt, type: FLOAT}
      - {name: bool, type: BOOLEAN}
      - {name: ts, type: TIMESTAMP, timestamp_format: "%Y-%m-%dT%H:%M:%S"}
      - {name: dt, type: DATETIME, timestamp_format: "%Y/%m/%d %H:%M:%S"}
      - {name: d, type: DATE}
      - {name: t, type: TIME}
```

## Test plan
- [ ] Unit tests pass
- [ ] Pre-release workflow runs on PR
- [ ] Pre-release gem is published to GPR
- [ ] Verify BigQuery transfer works correctly with pre-release gem in dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)