### PR TITLE
fix: serialize Hash/Array to JSON string in string_converter STRING case

### DIFF
--- a/lib/embulk/output/bigquery/value_converter_factory.rb
+++ b/lib/embulk/output/bigquery/value_converter_factory.rb
@@ -197,7 +197,8 @@ module Embulk
             }
           when 'STRING'
             Proc.new {|val|
-              val
+              next nil if val.nil?
+              val.is_a?(Hash) || val.is_a?(Array) ? val.to_json : val
             }
           when 'TIMESTAMP'
             if @timestamp_format

--- a/test/test_value_converter_factory.rb
+++ b/test/test_value_converter_factory.rb
@@ -226,6 +226,16 @@ module Embulk
           assert_equal "foo", converter.call("foo")
         end
 
+        def test_string_with_hash_value
+          converter = ValueConverterFactory.new(SCHEMA_TYPE, 'STRING').create_converter
+          assert_equal '{"key":"value"}', converter.call({"key" => "value"})
+        end
+
+        def test_string_with_array_value
+          converter = ValueConverterFactory.new(SCHEMA_TYPE, 'STRING').create_converter
+          assert_equal '[1,2,3]', converter.call([1, 2, 3])
+        end
+
         def test_timestamp
           converter = ValueConverterFactory.new(
             SCHEMA_TYPE, 'TIMESTAMP',
@@ -611,6 +621,18 @@ module Embulk
         def test_record_without_fields
           converter = ValueConverterFactory.new(:string, 'RECORD').create_converter
           assert_equal({'foo' => 'bar'}, converter.call('{"foo":"bar"}'))
+        end
+
+        def test_field_type_string_with_json_object_value
+          fields = [{'name' => 'v', 'type' => 'STRING', 'mode' => 'NULLABLE'}]
+          result = build_converter(:string, fields).call('{"v":{"key":"value","nested":[1,2,3]}}')
+          assert_equal '{"key":"value","nested":[1,2,3]}', result['v']
+        end
+
+        def test_field_type_string_with_array_value
+          fields = [{'name' => 'v', 'type' => 'STRING', 'mode' => 'NULLABLE'}]
+          result = build_converter(:string, fields).call('{"v":["a","b","c"]}')
+          assert_equal '["a","b","c"]', result['v']
         end
 
         def test_field_missing_in_data


### PR DESCRIPTION
## Summary
- Fix `string_converter` STRING case to serialize Hash/Array values with `.to_json` instead of passing them through as-is
- When a RECORD column has a nested field typed as STRING whose value is a JSON object/array from `JSON.parse`, the value was kept as a Hash/Array, causing BigQuery load jobs to fail with `JSON object specified for non-record field` error
- Add test cases for the fix

## Test plan
- [ ] `test_string_with_hash_value` — string_converter STRING serializes Hash to JSON string
- [ ] `test_string_with_array_value` — string_converter STRING serializes Array to JSON string
- [ ] `test_field_type_string_with_json_object_value` — RECORD nested field with JSON object value typed as STRING
- [ ] `test_field_type_string_with_array_value` — RECORD nested field with array value typed as STRING
- [ ] Verify BigQuery load job succeeds for RECORD columns containing `json_field` typed as STRING

🤖 Generated with [Claude Code](https://claude.com/claude-code)